### PR TITLE
Set the server name from the name of the selected folder

### DIFF
--- a/src/lib/js/wizard.js
+++ b/src/lib/js/wizard.js
@@ -24,6 +24,9 @@ $('#filebrowser').on('click',function(e){
 document.querySelector('#choosefile').addEventListener('change',function(evt){
   $('#path').val(this.value);
   UI.wizard.prepopulate();
+  if ($('#name').val().trim().length < 1) {
+    $('#name').val(path.basename(this.value));
+  }
   UI.wizard.valid() && UI.wizard.button.enable();
 },false);
 


### PR DESCRIPTION
As described in https://github.com/coreybutler/fenix/issues/18. If the server name field is empty when a folder is selected in the wizard, set the server name to match the name of the folder.
